### PR TITLE
Handle missing user id when fetching user

### DIFF
--- a/src/composables/useUser.ts
+++ b/src/composables/useUser.ts
@@ -8,10 +8,12 @@ const useUser = () => {
 
   const userLoading = ref(false);
 
-  async function fetchUser(id: number = userStore.getUser.id) {
+  async function fetchUser(id?: number) {
+    const targetId = id ?? userStore.getUser?.id;
+    if (!targetId) return;
     try {
       userLoading.value = true;
-      const u = await getUser(id);
+      const u = await getUser(targetId);
       if (u?.data) {
         userStore.setUser(u.data);
         return u;


### PR DESCRIPTION
## Summary
- read the user id from the argument or existing store value within `fetchUser`
- return early when no id is available before calling the API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cac2d51f088330be8de926e546b98b